### PR TITLE
Remove support for .Net Core 2.2 and add support for .Net Core 3.0/3.1

### DIFF
--- a/PineBlog.sln
+++ b/PineBlog.sln
@@ -16,7 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "00 Solution Files", "00 Sol
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "02 Tests", "02 Tests", "{39C10DDD-2F23-4F19-BBB1-CF31D9850002}"
 	ProjectSection(SolutionItems) = preProject
-		tests\test-netcoreapp2_2.ps1 = tests\test-netcoreapp2_2.ps1
+		tests\test-netcoreapp3_0.ps1 = tests\test-netcoreapp3_0.ps1
+		tests\test-netcoreapp3_1.ps1 = tests\test-netcoreapp3_1.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "10 Samples", "10 Samples", "{5FEBABA0-73A1-464A-8715-19F76F742B22}"
@@ -30,8 +31,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opw.PineBlog.Core", "src\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj", "{871343FA-6920-43B6-893F-B3127C04017E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opw.PineBlog.EntityFrameworkCore", "src\Opw.PineBlog.EntityFrameworkCore\Opw.PineBlog.EntityFrameworkCore.csproj", "{6F3FF55D-3189-4895-BA0A-9E0FEBB63339}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "90 Common", "90 Common", "{D524BD25-46D1-410E-A4AA-338422252720}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Opw.PineBlog.Abstractions.Tests", "tests\Opw.PineBlog.Abstractions.Tests\Opw.PineBlog.Abstractions.Tests.csproj", "{F47B0200-E3C4-4517-8C98-062DC246E8F6}"
 EndProject

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,13 @@ steps:
 - task: gittools.gitversion.gitversion-task.GitVersion@4
   displayName: GitVersion
 
+# TODO: remove when build image has dotnet-core 3.1
+# https://dotnet.microsoft.com/download/dotnet-core/3.1
+- task: DotNetCoreInstaller@0
+  displayName: 'Install .Net Core 3.1'
+  inputs:
+    version: '3.1.100-preview3-014645'
+
 - task: DotNetCoreCLI@2
   displayName: Build
   inputs:

--- a/ref/Opw.PineBlog/Opw.PineBlog.csproj
+++ b/ref/Opw.PineBlog/Opw.PineBlog.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
-        <Description>PineBlog; a light-weight blogging engine written in ASP.NET Core MVC Razor Pages, using Entity Framework Core.</Description>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageId>Opw.PineBlog</PackageId>
-        <PackageTags>blog aspnetcore mvc razorpages entityframeworkcore</PackageTags>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <Description>PineBlog; a light-weight blogging engine written in ASP.NET Core MVC Razor Pages, using Entity Framework Core.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Opw.PineBlog</PackageId>
+    <PackageTags>blog aspnetcore mvc razorpages entityframeworkcore</PackageTags>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Opw.PineBlog.EntityFrameworkCore\Opw.PineBlog.EntityFrameworkCore.csproj" />
-        <ProjectReference Include="..\..\src\Opw.PineBlog.RazorPages\Opw.PineBlog.RazorPages.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Opw.PineBlog.EntityFrameworkCore\Opw.PineBlog.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Opw.PineBlog.RazorPages\Opw.PineBlog.RazorPages.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/samples/Opw.PineBlog.Sample/Middleware/StopApplicationMiddleware.cs
+++ b/samples/Opw.PineBlog.Sample/Middleware/StopApplicationMiddleware.cs
@@ -1,6 +1,6 @@
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net;
@@ -11,14 +11,14 @@ namespace Opw.PineBlog.Sample.Middleware
     public class StopApplicationMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly IApplicationLifetime _applicationLifetime;
+        private readonly IHostApplicationLifetime _applicationLifetime;
         private readonly ILogger<StopApplicationMiddleware> _logger;
         private readonly string _restartPath;
 
         public StopApplicationMiddleware(
             RequestDelegate next,
             IConfiguration configuration,
-            IApplicationLifetime applicationLifetime,
+            IHostApplicationLifetime applicationLifetime,
             ILogger<StopApplicationMiddleware> logger)
         {
             _next = next;

--- a/samples/Opw.PineBlog.Sample/Opw.PineBlog.Sample.csproj
+++ b/samples/Opw.PineBlog.Sample/Opw.PineBlog.Sample.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.2" />
     <!--<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />-->
     <PackageReference Include="WaffleGenerator" Version="4.0.2" />
   </ItemGroup>

--- a/samples/Opw.PineBlog.Sample/Opw.PineBlog.Sample.csproj
+++ b/samples/Opw.PineBlog.Sample/Opw.PineBlog.Sample.csproj
@@ -14,10 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
     <!--<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />-->
     <PackageReference Include="WaffleGenerator" Version="4.0.2" />

--- a/samples/Opw.PineBlog.Sample/Opw.PineBlog.Sample.csproj
+++ b/samples/Opw.PineBlog.Sample/Opw.PineBlog.Sample.csproj
@@ -1,27 +1,30 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
-        <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <None Remove="Resources\post-pineblog-demo-website.md" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Remove="Resources\post-pineblog-demo-website.md" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <EmbeddedResource Include="Resources\post-pineblog-demo-website.md" />
-    </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\post-pineblog-demo-website.md" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
-        <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-        <PackageReference Include="WaffleGenerator" Version="4.0.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\ref\Opw.PineBlog\Opw.PineBlog.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
+    <!--<PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />-->
+    <PackageReference Include="WaffleGenerator" Version="4.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ref\Opw.PineBlog\Opw.PineBlog.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/samples/Opw.PineBlog.Sample/Program.cs
+++ b/samples/Opw.PineBlog.Sample/Program.cs
@@ -33,7 +33,6 @@ namespace Opw.PineBlog.Sample
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
                 .UseStartup<Startup>()
                 .ConfigureAppConfiguration((hostingContext, config) => {
                     config.AddPineBlogConfiguration(reloadOnChange: true);

--- a/samples/Opw.PineBlog.Sample/Startup.cs
+++ b/samples/Opw.PineBlog.Sample/Startup.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Opw.PineBlog.RazorPages;
 using Opw.PineBlog.Sample.Middleware;
-using Opw.PineBlog.EntityFrameworkCore;
 
 namespace Opw.PineBlog.Sample
 {
@@ -40,7 +39,7 @@ namespace Opw.PineBlog.Sample
             services.AddPineBlog(Configuration);
 
             services.AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddPineBlogRazorPages();
         }
 
@@ -65,9 +64,10 @@ namespace Opw.PineBlog.Sample
             app.UseStaticFiles();
             app.UseCookiePolicy();
 
+            app.UseRouting();
             app.UseAuthentication();
-
-            app.UseMvc();
+            app.UseAuthorization();
+            app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
         }
     }
 }

--- a/samples/Opw.PineBlog.Sample/Startup.cs
+++ b/samples/Opw.PineBlog.Sample/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Opw.PineBlog.RazorPages;
 using Opw.PineBlog.Sample.Middleware;
+using Microsoft.Extensions.Hosting;
 
 namespace Opw.PineBlog.Sample
 {
@@ -44,14 +45,14 @@ namespace Opw.PineBlog.Sample
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseMiddleware<StopApplicationMiddleware>();
 
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseDatabaseErrorPage();
+                //TODO: app.UseDatabaseErrorPage();
             }
             else
             {

--- a/samples/Opw.PineBlog.Sample/Startup.cs
+++ b/samples/Opw.PineBlog.Sample/Startup.cs
@@ -39,7 +39,7 @@ namespace Opw.PineBlog.Sample
             // TODO: combine with AddPineBlogRazorPages?
             services.AddPineBlog(Configuration);
 
-            services.AddMvc()
+            services.AddRazorPages()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddPineBlogRazorPages();
         }

--- a/samples/Opw.PineBlog.Sample/Startup.cs
+++ b/samples/Opw.PineBlog.Sample/Startup.cs
@@ -68,7 +68,7 @@ namespace Opw.PineBlog.Sample
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
-            app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+            app.UseEndpoints(endpoints => endpoints.MapRazorPages());
         }
     }
 }

--- a/src/Opw.PineBlog.Abstractions/Opw.PineBlog.Abstractions.csproj
+++ b/src/Opw.PineBlog.Abstractions/Opw.PineBlog.Abstractions.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>Opw.PineBlog</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Opw.EntityFrameworkCore" Version="1.0.1" />
+      <PackageReference Include="Opw.EntityFrameworkCore" Version="1.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Opw.PineBlog.Core/Opw.PineBlog.Core.csproj
+++ b/src/Opw.PineBlog.Core/Opw.PineBlog.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>Opw.PineBlog</RootNamespace>
         <Description>PineBlog core package.</Description>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Opw.PineBlog.Core/Opw.PineBlog.Core.csproj
+++ b/src/Opw.PineBlog.Core/Opw.PineBlog.Core.csproj
@@ -20,13 +20,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Markdig" Version="0.17.1" />
+        <PackageReference Include="Markdig" Version="0.18.0" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-        <PackageReference Include="MimeMapping" Version="1.0.1.15" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0" />
+        <PackageReference Include="MimeMapping" Version="1.0.1.17" />
         <PackageReference Include="System.ServiceModel.Syndication" Version="4.5.0" />
     </ItemGroup>
 

--- a/src/Opw.PineBlog.Core/Opw.PineBlog.Core.nuspec
+++ b/src/Opw.PineBlog.Core/Opw.PineBlog.Core.nuspec
@@ -15,12 +15,12 @@
         <dependencies>
             <group targetFramework=".NETStandard2.0">
                 <!-- Opw.PineBlog.Core -->
-                <dependency id="Markdig" version="0.17.1" exclude="Build,Analyzers" />
+                <dependency id="Markdig" version="0.18.0" exclude="Build,Analyzers" />
                 <dependency id="MediatR.Extensions.Microsoft.DependencyInjection" version="7.0.0" exclude="Build,Analyzers" />
                 <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.2.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Extensions.Options" version="2.2.0" exclude="Build,Analyzers" />
-                <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.2.0" exclude="Build,Analyzers" />
-                <dependency id="MimeMapping" version="1.0.1.15" exclude="Build,Analyzers" />
+                <dependency id="Microsoft.Extensions.Options" version="3.0.0" exclude="Build,Analyzers" />
+                <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="3.0.0" exclude="Build,Analyzers" />
+                <dependency id="MimeMapping" version="1.0.1.17" exclude="Build,Analyzers" />
                 <dependency id="Microsoft.Azure.Storage.Blob" version="11.0.0" exclude="Build,Analyzers" />
                 <dependency id="System.ServiceModel.Syndication" version="4.5.0" exclude="Build,Analyzers" />
 

--- a/src/Opw.PineBlog.EntityFrameworkCore/BlogEntityDbContext.cs
+++ b/src/Opw.PineBlog.EntityFrameworkCore/BlogEntityDbContext.cs
@@ -20,7 +20,7 @@ namespace Opw.PineBlog.EntityFrameworkCore
 
             foreach (var entityType in modelBuilder.Model.GetEntityTypes())
             {
-                entityType.Relational().TableName = $"PineBlog_{entityType.Relational().TableName}";
+                entityType.SetTableName($"PineBlog_{entityType.GetTableName()}");
             }
         }
     }

--- a/src/Opw.PineBlog.EntityFrameworkCore/Opw.PineBlog.EntityFrameworkCore.csproj
+++ b/src/Opw.PineBlog.EntityFrameworkCore/Opw.PineBlog.EntityFrameworkCore.csproj
@@ -1,25 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
-        <Description>PineBlog data provider that uses Entity Framework Core.</Description>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageId>Opw.PineBlog.EntityFrameworkCore</PackageId>
-        <PackageTags>blog entity framework core entityframeworkcore</PackageTags>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <Description>PineBlog data provider that uses Entity Framework Core.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Opw.PineBlog.EntityFrameworkCore</PackageId>
+    <PackageTags>blog entity framework core entityframeworkcore</PackageTags>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Opw.PineBlog.RazorPages/Opw.PineBlog.RazorPages.csproj
+++ b/src/Opw.PineBlog.RazorPages/Opw.PineBlog.RazorPages.csproj
@@ -1,40 +1,45 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <RootNamespace>Opw.PineBlog.RazorPages</RootNamespace>
-        <Description>PineBlog UI using ASP.NET Core MVC Razor Pages.</Description>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageId>Opw.PineBlog.RazorPages</PackageId>
-        <PackageTags>blog aspnetcore mvc razor razorpages</PackageTags>
-        <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+    <RootNamespace>Opw.PineBlog.RazorPages</RootNamespace>
+    <Description>PineBlog UI using ASP.NET Core MVC Razor Pages.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Opw.PineBlog.RazorPages</PackageId>
+    <PackageTags>blog aspnetcore mvc razor razorpages</PackageTags>
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+  </PropertyGroup>
 
-    <Target Name="MyPreCompileTarget" BeforeTargets="Build">
-        <!-- Ensure Node.js is installed -->
-        <Exec Command="node --version" ContinueOnError="true">
-            <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
-        </Exec>
-        <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
-        <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-        <Exec WorkingDirectory="$(ProjectDir)" Command="npm install" />
-        <Exec WorkingDirectory="$(ProjectDir)" Command="node_modules\.bin\gulp default" />
-    </Target>
+  <Target Name="MyPreCompileTarget" BeforeTargets="Build">
+    <!-- Ensure Node.js is installed -->
+    <Exec Command="node --version" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
+    </Exec>
+    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
+    <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="npm install" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="node_modules\.bin\gulp default" />
+  </Target>
 
-    <ItemGroup>
-        <PackageReference Include="FluentValidation.AspNetCore" Version="8.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.5.0" />
+    <!--<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.2.0" />
-    </ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.2.0" />-->
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <EmbeddedResource Include="wwwroot\**\css\*" />
-        <EmbeddedResource Include="wwwroot\**\js\*" />
-    </ItemGroup>
-    
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\**\css\*" />
+    <EmbeddedResource Include="wwwroot\**\js\*" />
+  </ItemGroup>
+
 </Project>

--- a/src/Opw.PineBlog.RazorPages/Opw.PineBlog.RazorPages.csproj
+++ b/src/Opw.PineBlog.RazorPages/Opw.PineBlog.RazorPages.csproj
@@ -28,9 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.5.0" />
-    <!--<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.2.0" />-->
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Opw.PineBlog.RazorPages/StaticFilePostConfigureOptions.cs
+++ b/src/Opw.PineBlog.RazorPages/StaticFilePostConfigureOptions.cs
@@ -12,12 +12,12 @@ namespace Opw.PineBlog.RazorPages
     /// </summary>
     public class StaticFilePostConfigureOptions : IPostConfigureOptions<StaticFileOptions>
     {
-        private readonly IHostingEnvironment _environment;
+        private readonly IWebHostEnvironment _environment;
 
         /// <summary>
         /// Initializes the StaticFilePostConfigureOptions.
         /// </summary>
-        public StaticFilePostConfigureOptions(IHostingEnvironment environment)
+        public StaticFilePostConfigureOptions(IWebHostEnvironment environment)
         {
             _environment = environment;
         }

--- a/tests/Opw.PineBlog.Abstractions.Tests/Opw.PineBlog.Abstractions.Tests.csproj
+++ b/tests/Opw.PineBlog.Abstractions.Tests/Opw.PineBlog.Abstractions.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Opw.PineBlog.Abstractions.Tests/Opw.PineBlog.Abstractions.Tests.csproj
+++ b/tests/Opw.PineBlog.Abstractions.Tests/Opw.PineBlog.Abstractions.Tests.csproj
@@ -1,29 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Opw.PineBlog</RootNamespace>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-        <RootNamespace>Opw.PineBlog</RootNamespace>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Opw.PineBlog.Abstractions\Opw.PineBlog.Abstractions.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Opw.PineBlog.Abstractions\Opw.PineBlog.Abstractions.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Opw.PineBlog.Core.Tests/Opw.PineBlog.Core.Tests.csproj
+++ b/tests/Opw.PineBlog.Core.Tests/Opw.PineBlog.Core.Tests.csproj
@@ -1,37 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Opw.PineBlog</RootNamespace>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-        <RootNamespace>Opw.PineBlog</RootNamespace>
-    </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Opw.PineBlog.EntityFrameworkCore\Opw.PineBlog.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-        <PackageReference Include="Moq" Version="4.13.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Opw.PineBlog.EntityFrameworkCore\Opw.PineBlog.EntityFrameworkCore.csproj" />
-        <ProjectReference Include="..\..\src\Opw.PineBlog.Core\Opw.PineBlog.Core.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Update="appsettings.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/tests/Opw.PineBlog.Core.Tests/Opw.PineBlog.Core.Tests.csproj
+++ b/tests/Opw.PineBlog.Core.Tests/Opw.PineBlog.Core.Tests.csproj
@@ -12,8 +12,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Opw.PineBlog.EntityFrameworkCore.Tests/Opw.PineBlog.EntityFrameworkCore.Tests.csproj
+++ b/tests/Opw.PineBlog.EntityFrameworkCore.Tests/Opw.PineBlog.EntityFrameworkCore.Tests.csproj
@@ -1,10 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
-
     <RootNamespace>Opw.PineBlog.EntityFrameworkCore</RootNamespace>
   </PropertyGroup>
 
@@ -14,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Opw.PineBlog.EntityFrameworkCore.Tests/Opw.PineBlog.EntityFrameworkCore.Tests.csproj
+++ b/tests/Opw.PineBlog.EntityFrameworkCore.Tests/Opw.PineBlog.EntityFrameworkCore.Tests.csproj
@@ -13,8 +13,8 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Opw.PineBlog.RazorPages.Tests/Opw.PineBlog.RazorPages.Tests.csproj
+++ b/tests/Opw.PineBlog.RazorPages.Tests/Opw.PineBlog.RazorPages.Tests.csproj
@@ -1,30 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Opw.PineBlog</RootNamespace>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-        <RootNamespace>Opw.PineBlog</RootNamespace>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="2.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="5.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-        <PackageReference Include="Moq" Version="4.13.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Opw.PineBlog.RazorPages\Opw.PineBlog.RazorPages.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Opw.PineBlog.RazorPages\Opw.PineBlog.RazorPages.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Opw.PineBlog.RazorPages.Tests/Opw.PineBlog.RazorPages.Tests.csproj
+++ b/tests/Opw.PineBlog.RazorPages.Tests/Opw.PineBlog.RazorPages.Tests.csproj
@@ -12,8 +12,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/test-netcoreapp2_2.ps1
+++ b/tests/test-netcoreapp2_2.ps1
@@ -1,3 +1,0 @@
-dotnet build ../PineBlog.sln --configuration Release
-dotnet test ../PineBlog.sln --configuration Release --framework netcoreapp2.2 --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Include="[Opw.*]*" /p:Exclude="[*.Tests]*%2c[*.*Tests]*"
-PAUSE

--- a/tests/test-netcoreapp3_0.ps1
+++ b/tests/test-netcoreapp3_0.ps1
@@ -1,0 +1,3 @@
+dotnet build ../HttpExceptions.sln --configuration Release
+dotnet test ../HttpExceptions.sln --configuration Release --framework netcoreapp3.0 --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Include="[Opw.*]*" /p:Exclude="[*.Tests]*%2c[*.*Tests]*"
+PAUSE

--- a/tests/test-netcoreapp3_1.ps1
+++ b/tests/test-netcoreapp3_1.ps1
@@ -1,0 +1,3 @@
+dotnet build ../HttpExceptions.sln --configuration Release
+dotnet test ../HttpExceptions.sln --configuration Release --framework netcoreapp3.1 --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Include="[Opw.*]*" /p:Exclude="[*.Tests]*%2c[*.*Tests]*"
+PAUSE


### PR DESCRIPTION
Add support for .Net Core 3.0 #64
Stop support for .NET Core 2.2 when EOL (2019-12-23) #65

closes #64 
closes #65