### PR TITLE
Remove the _ValidationScriptsPartial from Opw.PineBlog.RazorPages

### DIFF
--- a/docs/custom-layout.md
+++ b/docs/custom-layout.md
@@ -1,6 +1,6 @@
 # Customizing the layout
 For the **Blog** area you need to override the `_Layout.cshtml` for the pages, to do this create a new `_Layout.cshtml` page in the
-`Areas/Blog/Shared` folder. This will make the blog pages use that layout page instead of the one included in the `Opw.PineBlog.RazorPages` package. 
+`~/Areas/Blog/Pages/Shared` folder. This will make the blog pages use that layout page instead of the one included in the `Opw.PineBlog.RazorPages` package.
 In the new page you can set the layout page of your website. Make sure to add the `head` and `script` sections.
 
 ``` csharp
@@ -85,3 +85,31 @@ For an example have a look at the sample project where we override the footer
 
 # Admin layout
 For the **Admin** area layout page do the same as you did for the **Blog** area.
+
+## Client-side validation
+To enable client-side validation you need to add `jquery.validate` or a client-side validation library of your choice.
+
+You need to override the `_ValidationScriptsPartial.cshtml` in the `Admin` area, to do this create a new `_ValidationScriptsPartial.cshtml` page
+in the `~/Areas/Admin/Pages/Shared` folder. For an example have a look at the sample project.
+
+Example `_ValidationScriptsPartial.cshtml` partial code:
+``` html
+<environment include="Development">
+    <script src="~/js/jquery.validate.js"></script>
+    <script src="~/js/jquery.validate.unobtrusive.js"></script>
+</environment>
+<environment exclude="Development">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"
+            asp-fallback-src="~/js/jquery.validate.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator"
+            crossorigin="anonymous"
+            integrity="sha256-F6h55Qw6sweK+t7SiOJX+2bpSAa3b/fnlrVCJvmEj1A=">
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js"
+            asp-fallback-src="~/js/jquery.validate.unobtrusive.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive"
+            crossorigin="anonymous"
+            integrity="sha256-9GycpJnliUjJDVDqP0UEu/bsm9U+3dnQUH8+3W10vkY=">
+    </script>
+</environment>
+```

--- a/samples/Opw.PineBlog.Sample.NuGet/appsettings.json
+++ b/samples/Opw.PineBlog.Sample.NuGet/appsettings.json
@@ -11,7 +11,7 @@
     "DefaultConnection": "Server=inMemory; Database=pineblog-db;",
     "MongoDbConnection": "inMemory"
   },
-  "PineBlogDataSource": "MongoDb", // EntityFrameworkCore or MongoDb
+  "PineBlogDataSource": "EntityFrameworkCore", // EntityFrameworkCore or MongoDb
   "PineBlogOptions": {
     "Title": "PineBlog NuGet",
     "Description": "Sample project for basic setup with the NuGet pacakges.",

--- a/samples/Opw.PineBlog.Sample/Areas/Admin/Pages/Shared/_ValidationScriptsPartial.cshtml
+++ b/samples/Opw.PineBlog.Sample/Areas/Admin/Pages/Shared/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,18 @@
+<environment include="Development">
+    <script src="~/js/jquery.validate.js"></script>
+    <script src="~/js/jquery.validate.unobtrusive.js"></script>
+</environment>
+<environment exclude="Development">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"
+            asp-fallback-src="~/js/jquery.validate.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator"
+            crossorigin="anonymous"
+            integrity="sha256-F6h55Qw6sweK+t7SiOJX+2bpSAa3b/fnlrVCJvmEj1A=">
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js"
+            asp-fallback-src="~/js/jquery.validate.unobtrusive.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive"
+            crossorigin="anonymous"
+            integrity="sha256-9GycpJnliUjJDVDqP0UEu/bsm9U+3dnQUH8+3W10vkY=">
+    </script>
+</environment>

--- a/samples/Opw.PineBlog.Sample/appsettings.json
+++ b/samples/Opw.PineBlog.Sample/appsettings.json
@@ -4,7 +4,7 @@
     "DefaultConnection": "Server=inMemory; Database=pineblog-db;",
     "MongoDbConnection": "inMemory"
   },
-  "PineBlogDataSource": "MongoDb", // EntityFrameworkCore or MongoDb
+  "PineBlogDataSource": "EntityFrameworkCore", // EntityFrameworkCore or MongoDb
   "PineBlogOptions": {
     "Title": "PineBlog",
     "Description": "A blogging engine based on ASP.NET Core MVC Razor Pages and Entity Framework Core",

--- a/src/Opw.PineBlog.RazorPages/Areas/Admin/Pages/Shared/_Layout.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Admin/Pages/Shared/_Layout.cshtml
@@ -5,9 +5,34 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>@ViewData["Title"]</title>
     @RenderSection("head", required: false)
+    <style>
+        .alert.alert-warning {
+            position: relative;
+            padding: .75rem 1.25rem;
+            margin-top: 1rem;
+            margin-bottom: 1rem;
+            border: 1px solid #ffeeba;
+            border-radius: .25rem;
+            color: #856404;
+            background-color: #fff3cd;
+        }
+
+            .alert.alert-warning h4 {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
+    </style>
 </head>
 <body>
-    <h1>Add a custom <code>_AdminLayout.cshtml</code> page to your web project in the folder <code>./Areas/Admin/Pages/Shared/</code></h1>
+    <div class="alert alert-warning" role="alert">
+        <h4 class="alert-heading">TODO!</h4>
+        <p>
+            Add a custom <code>_AdminLayout.cshtml</code> page to your web project in the folder <code>~/Areas/Admin/Pages/Shared</code>.<br />
+            This will make the Admin pages use that layout page instead of the one your are seeing now.
+            <hr />
+            See <a href="https://github.com/ofpinewood/pineblog/blob/master/docs/custom-layout.md">customizing the layout</a> for more information.
+        </p>
+    </div>
     @RenderBody()
 
     @RenderSection("scripts", required: false)

--- a/src/Opw.PineBlog.RazorPages/Areas/Admin/Pages/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Admin/Pages/Shared/_ValidationScriptsPartial.cshtml
@@ -1,18 +1,11 @@
-<environment include="Development">
-    <script src="~/js/jquery.validate.js"></script>
-    <script src="~/js/jquery.validate.unobtrusive.js"></script>
-</environment>
-<environment exclude="Development">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"
-            asp-fallback-src="~/js/jquery.validate.min.js"
-            asp-fallback-test="window.jQuery && window.jQuery.validator"
-            crossorigin="anonymous"
-            integrity="sha256-F6h55Qw6sweK+t7SiOJX+2bpSAa3b/fnlrVCJvmEj1A=">
-    </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js"
-            asp-fallback-src="~/js/jquery.validate.unobtrusive.min.js"
-            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive"
-            crossorigin="anonymous"
-            integrity="sha256-9GycpJnliUjJDVDqP0UEu/bsm9U+3dnQUH8+3W10vkY=">
-    </script>
-</environment>
+<div class="alert alert-warning" role="alert">
+    <h4 class="alert-heading">TODO!</h4>
+    <p>To enable client-side validation you need to add <code>jquery.validate</code> or a client-side validation library of your choice.</p>
+    <p class="mb-0">
+        You need to override the `_ValidationScriptsPartial.cshtml` in the `Admin` area, to do this create a new `_ValidationScriptsPartial.cshtml` page
+        in the `~/Areas/Admin/Pages/Shared` folder.<br />
+        This will make the Admin pages use that partial instead of the one your are seeing now.
+    </p>
+    <hr />
+    See <a href="https://github.com/ofpinewood/pineblog/blob/master/docs/custom-layout.md#client-side-validation">customizing the layout</a> for more information.
+</div>

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_Layout.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_Layout.cshtml
@@ -5,9 +5,34 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>@ViewData["Title"]</title>
     @RenderSection("head", required: false)
+    <style>
+        .alert.alert-warning {
+            position: relative;
+            padding: .75rem 1.25rem;
+            margin-top: 1rem;
+            margin-bottom: 1rem;
+            border: 1px solid #ffeeba;
+            border-radius: .25rem;
+            color: #856404;
+            background-color: #fff3cd;
+        }
+
+            .alert.alert-warning h4 {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
+    </style>
 </head>
 <body class="pineblog">
-    <h1>Add a custom <code>_Layout.cshtml</code> page to your web project in the folder <code>./Areas/Blog/Pages/Shared/</code></h1>
+    <div class="alert alert-warning" role="alert">
+        <h4 class="alert-heading">TODO!</h4>
+        <p>
+            Add a custom <code>_Layout.cshtml</code> page to your web project in the folder <code>~/Areas/Blog/Pages/Shared</code>.<br />
+            This will make the Blog pages use that layout page instead of the one your are seeing now.
+            <hr />
+            See <a href="https://github.com/ofpinewood/pineblog/blob/master/docs/custom-layout.md">customizing the layout</a> for more information.
+        </p>
+    </div>
     @RenderBody()
 
     @RenderSection("scripts", required: false)


### PR DESCRIPTION
Removed the '_ValidationScriptsPartial' from 'Opw.PineBlog.RazorPages', this should be added to in the actual web project.

It contains the following code. This should be defined in the web project since it is trying to include jquery.validate, and we want the developer to be flexible in how they want to include this library.

#101 