### PR TITLE
Search posts functionality

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,10 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+
 [*.cs]
 #.NET code style settings
 # ref: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NuGet Badge](https://img.shields.io/nuget/v/Opw.PineBlog.svg)](https://www.nuget.org/packages/Opw.PineBlog/)
 [![License: MIT](https://img.shields.io/github/license/ofpinewood/pineblog.svg)](https://github.com/ofpinewood/pineblog/blob/master/LICENSE)
 
-PineBlog is a light-weight blogging engine written in ASP.NET Core MVC Razor Pages, using Entity Framework Core or MongoDb. It is highly extendable, customizable and easy to integrate in an existing web application.
+PineBlog is a light-weight blogging engine written in ASP.NET Core MVC Razor Pages, using Entity Framework Core or MongoDb. It is highly extendable, customizable and easy to integrate in an existing web application. 
 
 ![PineBlog screenshot](docs/screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ PineBlog is a light-weight blogging engine written in ASP.NET Core MVC Razor Pag
 - SEO optimized
 - Open Graph protocol
 - RSS and ATOM feeds
+- Basic search
 - Clean Architecture (youtube: [Clean Architecture with ASP.NET Core](https://youtu.be/_lwCVE_XgqI))
 - Entity Framework Core, SQL database
 - or MongoDb ([MongoDB.Driver](https://www.nuget.org/packages/mongodb.driver))

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ For technical background information, check the blog: [ofpinewood.com](https://o
 The demo website is a playground to check out PineBlog. You can write and publish posts, upload files and test application before install.
 And no worries, it is just a sandbox and will clean itself.
 
-> **Url:** [pineblog.azurewebsites.net](https://pineblog.azurewebsites.net)
-> **Username:** pineblog@example.com
-> **Password:** demo
+> **Url:** [pineblog.azurewebsites.net](https://pineblog.azurewebsites.net)  
+> **Username:** pineblog@example.com  
+> **Password:** demo  
 
 ## Usage
 PineBlog is used on the following website:

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,6 +5,8 @@
 - Light-weight using Razor Pages
 - SEO optimized
 - Open Graph protocol
+- RSS and ATOM feeds
+- Basic search
 - Clean Architecture (youtube: [Clean Architecture with ASP.NET Core](https://youtu.be/_lwCVE_XgqI))
 - Entity Framework Core, SQL database
 - or MongoDb ([MongoDB.Driver](https://www.nuget.org/packages/mongodb.driver))

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ public void ConfigureServices(IServiceCollection services)
 {
     ...
     services.AddPineBlog(Configuration);
-    
+
     services.AddRazorPages().AddPineBlogRazorPages();
     // or services.AddMvcCore().AddPineBlogRazorPages();
     // or services.AddMvc().AddPineBlogRazorPages();
@@ -29,21 +29,21 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 }
 ```
 
-NOTE: Make sure you enable static file serving `app.UseStaticFiles();`, to enable the serving of the css and javascript from the `Opw.PineBlog.RazorPages` packages.  
+NOTE: Make sure you enable static file serving `app.UseStaticFiles();`, to enable the serving of the css and javascript from the `Opw.PineBlog.RazorPages` packages.
 
-See [Customizing the layout](https://github.com/ofpinewood/pineblog/tree/master/docs/custom-layout.md) on how to setup the layout pages, css and javascript.  
+See [Customizing the layout](https://github.com/ofpinewood/pineblog/tree/master/docs/custom-layout.md) on how to setup the layout pages, css and javascript.
 
 ## Configuration
 A few properties need to be configured before you can run your web application with PineBlog.
 
-**Title:** the title of your blog/website.  
-**CoverUrl:** the URL for the cover image of your blog, this can be a relative or absolute URL.  
-**ConnectionStringName:** this is the name to the connection string used in your application.  
+**Title:** the title of your blog/website.
+**CoverUrl:** the URL for the cover image of your blog, this can be a relative or absolute URL.
+**ConnectionStringName:** this is the name to the connection string used in your application.
 **CreateAndSeedDatabases:** to automatically create and seed the tables for the blog set this property to `true`, if you want to create and seed your
-database in any other way set this property to `false`.  
-**AzureStorageConnectionString:** your Azure Blog Storage connection string.  
-**AzureStorageBlobContainerName:** the name of the blob container to use for file storage.  
-**FileBaseUrl:** the base URL for the files, this should be the URL for your Azure Blob Storage, e.g. `https://<storage-account>.blob.core.windows.net`.  
+database in any other way set this property to `false`.
+**AzureStorageConnectionString:** your Azure Blog Storage connection string.
+**AzureStorageBlobContainerName:** the name of the blob container to use for file storage.
+**FileBaseUrl:** the base URL for the files, this should be the URL for your Azure Blob Storage, e.g. `https://<storage-account>.blob.core.windows.net`.
 
 The rest of the properties are optional and will be set with default values if you don't specify them.
 
@@ -59,6 +59,7 @@ The rest of the properties are optional and will be set with default values if y
         "CoverCaption": "Battle background for the Misty Woods in the game Shadows of Adam by Tim Wendorf",
         "CoverLink": "http://pixeljoint.com/pixelart/94359.htm",
         "ItemsPerPage": 5,
+        "EnableSearch": true, // default: false
         "CreateAndSeedDatabases": true,
         "ConnectionStringName": "DefaultConnection",
         "AzureStorageConnectionString": "UseDevelopmentStorage=true",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ The rest of the properties are optional and will be set with default values if y
         "CoverCaption": "Battle background for the Misty Woods in the game Shadows of Adam by Tim Wendorf",
         "CoverLink": "http://pixeljoint.com/pixelart/94359.htm",
         "ItemsPerPage": 5,
-        "EnableSearch": true, // default: false
+        "EnableSearch": true, // default is true
         "CreateAndSeedDatabases": true,
         "ConnectionStringName": "DefaultConnection",
         "AzureStorageConnectionString": "UseDevelopmentStorage=true",

--- a/samples/Opw.PineBlog.Sample.NuGet/MongoDbInMemoryRunner.cs
+++ b/samples/Opw.PineBlog.Sample.NuGet/MongoDbInMemoryRunner.cs
@@ -37,9 +37,7 @@ namespace Opw.PineBlog.Sample.NuGet
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-            }
+            if (disposing) { }
 
             // always try to dispose, even if disposing=false
             if (_runner != null)

--- a/samples/Opw.PineBlog.Sample/appsettings.json
+++ b/samples/Opw.PineBlog.Sample/appsettings.json
@@ -12,6 +12,7 @@
     "CoverCaption": "Battle background for the Misty Woods in the game Shadows of Adam by Tim Wendorf",
     "CoverLink": "http://pixeljoint.com/pixelart/94359.htm",
     "ItemsPerPage": 2,
+    "EnableSearch": true,
     "CreateAndSeedDatabases": true,
     "ConnectionStringName": "DefaultConnection",
     "MongoDbDatabaseName": "pineblog-db",

--- a/src/Opw.PineBlog.Abstractions/Models/PostListModel.cs
+++ b/src/Opw.PineBlog.Abstractions/Models/PostListModel.cs
@@ -19,6 +19,11 @@ namespace Opw.PineBlog.Models
         public string Category { get; set; }
 
         /// <summary>
+        /// The search query that was used to filtered on, or NULL.
+        /// </summary>
+        public string SearchQuery { get; set; }
+
+        /// <summary>
         /// The list of posts for the current page.
         /// </summary>
         public IEnumerable<Post> Posts { get; set; }

--- a/src/Opw.PineBlog.Abstractions/Models/PostListType.cs
+++ b/src/Opw.PineBlog.Abstractions/Models/PostListType.cs
@@ -21,9 +21,9 @@ namespace Opw.PineBlog.Models
         /// </summary>
         Category = 2,
 
-        ///// <summary>
-        ///// Search results
-        ///// </summary>
-        //Search
+        /// <summary>
+        /// Search results
+        /// </summary>
+        Search
     }
 }

--- a/src/Opw.PineBlog.Abstractions/PineBlogOptions.cs
+++ b/src/Opw.PineBlog.Abstractions/PineBlogOptions.cs
@@ -41,9 +41,9 @@ namespace Opw.PineBlog
         public string SearchQueryUrlPartFormat { get; set; }
 
         /// <summary>
-        /// Enable search, or not.
+        /// Enable search, default is true.
         /// </summary>
-        public bool EnableSearch { get; set; }
+        public bool EnableSearch { get; set; } = true;
 
         public bool CreateAndSeedDatabases { get; set; }
 

--- a/src/Opw.PineBlog.Abstractions/PineBlogOptions.cs
+++ b/src/Opw.PineBlog.Abstractions/PineBlogOptions.cs
@@ -38,6 +38,7 @@ namespace Opw.PineBlog
 
         public string PagingUrlPartFormat { get; set; }
         public string CategoryUrlPartFormat { get; set; }
+        public string SearchQueryUrlPartFormat { get; set; }
         public bool CreateAndSeedDatabases { get; set; }
 
         /// <summary>

--- a/src/Opw.PineBlog.Abstractions/PineBlogOptions.cs
+++ b/src/Opw.PineBlog.Abstractions/PineBlogOptions.cs
@@ -39,6 +39,12 @@ namespace Opw.PineBlog
         public string PagingUrlPartFormat { get; set; }
         public string CategoryUrlPartFormat { get; set; }
         public string SearchQueryUrlPartFormat { get; set; }
+
+        /// <summary>
+        /// Enable search, or not.
+        /// </summary>
+        public bool EnableSearch { get; set; }
+
         public bool CreateAndSeedDatabases { get; set; }
 
         /// <summary>

--- a/src/Opw.PineBlog.Core/Posts/SearchPostsQuery.cs
+++ b/src/Opw.PineBlog.Core/Posts/SearchPostsQuery.cs
@@ -1,0 +1,122 @@
+using MediatR;
+using Microsoft.Extensions.Options;
+using Opw.PineBlog.Entities;
+using Opw.PineBlog.Files;
+using Opw.PineBlog.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace Opw.PineBlog.Posts
+{
+    /// <summary>
+    /// Query that searches posts.
+    /// </summary>
+    public class SearchPostsQuery : IRequest<Result<PostListModel>>
+    {
+        /// <summary>
+        /// The requested page.
+        /// </summary>
+        public int Page { get; set; } = 1;
+
+        /// <summary>
+        /// The number of items per page, if not set the BlogOptions.ItemsPerPage will be used.
+        /// </summary>
+        public int? ItemsPerPage { get; set; }
+
+        /// <summary>
+        /// Text to search for.
+        /// </summary>
+        public string SearchQuery { get; set; }
+
+        /// <summary>
+        /// Handler for the SearchPostsQuery.
+        /// </summary>
+        public class Handler : IRequestHandler<SearchPostsQuery, Result<PostListModel>>
+        {
+            private readonly IOptionsSnapshot<PineBlogOptions> _blogOptions;
+            private readonly IBlogUnitOfWork _uow;
+            private readonly PostUrlHelper _postUrlHelper;
+            private readonly FileUrlHelper _fileUrlHelper;
+
+            /// <summary>
+            /// Implementation of SearchPostsQuery.Handler.
+            /// </summary>
+            /// <param name="uow">The blog unit of work.</param>
+            /// <param name="blogOptions">The blog options.</param>
+            /// <param name="postUrlHelper">Post URL helper.</param>
+            /// <param name="fileUrlHelper">File URL helper.</param>
+            public Handler(IBlogUnitOfWork uow, IOptionsSnapshot<PineBlogOptions> blogOptions, PostUrlHelper postUrlHelper, FileUrlHelper fileUrlHelper)
+            {
+                _blogOptions = blogOptions;
+                _uow = uow;
+                _postUrlHelper = postUrlHelper;
+                _fileUrlHelper = fileUrlHelper;
+            }
+
+            /// <summary>
+            /// Handle the SearchPostsQuery request.
+            /// </summary>
+            /// <param name="request">The SearchPostsQuery request.</param>
+            /// <param name="cancellationToken">A cancellation token.</param>
+            public async Task<Result<PostListModel>> Handle(SearchPostsQuery request, CancellationToken cancellationToken)
+            {
+                var itemsPerPage = (request.ItemsPerPage.HasValue) ? request.ItemsPerPage : _blogOptions.Value.ItemsPerPage;
+                var pager = new Pager(request.Page, itemsPerPage.Value);
+
+                var pagingUrlPartFormat = _blogOptions.Value.PagingUrlPartFormat;
+
+                var predicates = new List<Expression<Func<Post, bool>>>();
+                predicates.Add(p => p.Published != null);
+
+                if (!string.IsNullOrWhiteSpace(request.SearchQuery))
+                {
+                    // TODO: add more weight to the title and categories
+                    predicates.Add(p =>
+                        p.Title.Contains(request.SearchQuery) ||
+                        p.Categories.Contains(request.SearchQuery) ||
+                        p.Description.Contains(request.SearchQuery) ||
+                        p.Content.Contains(request.SearchQuery));
+
+                    pagingUrlPartFormat += "&" + string.Format(_blogOptions.Value.SearchQueryUrlPartFormat, HttpUtility.UrlEncode(request.SearchQuery));
+                }
+
+                var posts = await GetPagedListAsync(predicates, pager, pagingUrlPartFormat, cancellationToken);
+
+                posts = posts.Select(p => _postUrlHelper.ReplaceUrlFormatWithBaseUrl(p));
+
+                var model = new PostListModel
+                {
+                    Blog = new BlogModel(_blogOptions.Value),
+                    PostListType = PostListType.Blog,
+                    Posts = posts,
+                    Pager = pager
+                };
+
+                model.Blog.CoverUrl = _fileUrlHelper.ReplaceUrlFormatWithBaseUrl(model.Blog.CoverUrl);
+
+                if (!string.IsNullOrWhiteSpace(request.SearchQuery))
+                {
+                    model.PostListType = PostListType.Search;
+                    model.SearchQuery = request.SearchQuery;
+                }
+
+                return Result<PostListModel>.Success(model);
+            }
+
+            private async Task<IEnumerable<Post>> GetPagedListAsync(IEnumerable<Expression<Func<Post, bool>>> predicates, Pager pager, string pagingUrlPartFormat, CancellationToken cancellationToken)
+            {
+                var skip = (pager.CurrentPage - 1) * pager.ItemsPerPage;
+                var count = await _uow.Posts.CountAsync(predicates, cancellationToken);
+
+                pager.Configure(count, pagingUrlPartFormat);
+
+                return await _uow.Posts.GetAsync(predicates, skip, pager.ItemsPerPage, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml
@@ -1,7 +1,15 @@
 @page
 @model IndexModel
 @{
-    ViewData["ShowSearch"] = true;
+    var isSearch = Model.PostList.PostListType == PineBlog.Models.PostListType.Search;
+
+    var linkToNewerText = "Newer";
+    var linkToOlderText = "Older";
+    if (isSearch)
+    {
+        linkToNewerText = "Previous";
+        linkToOlderText = "Next";
+    }
 }
 @section head {
     <partial name="_Metadata" model="@Model.Metadata" />
@@ -11,6 +19,14 @@
 
 <div class="page-content">
     <div class="container">
+        @if (isSearch && !Model.PostList.Posts.Any())
+        {
+            <article class="post">
+                <div class="post-content">
+                    No results for "@ViewData["SearchQuery"]"
+                </div>
+            </article>
+        }
         @foreach (var post in Model.PostList.Posts)
         {
             <partial name="_Post" model="post" />
@@ -21,16 +37,16 @@
                 <div class="item-next col-md-6">
                     @if (Model.PostList.Pager.ShowNewer)
                     {
-                        <a href="?@Model.PostList.Pager.LinkToNewer" title="Newer">
-                            Newer
+                        <a href="?@Model.PostList.Pager.LinkToNewer" title="@linkToNewerText">
+                            @linkToNewerText
                         </a>
                     }
                 </div>
                 <div class="item-prev col-md-6">
                     @if (Model.PostList.Pager.ShowOlder)
                     {
-                        <a href="?@Model.PostList.Pager.LinkToOlder" title="Older">
-                            Older
+                        <a href="?@Model.PostList.Pager.LinkToOlder" title="@linkToOlderText">
+                            @linkToOlderText
                         </a>
                     }
                 </div>

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml
@@ -1,5 +1,8 @@
 @page
 @model IndexModel
+@{
+    ViewData["ShowSearch"] = true;
+}
 @section head {
     <partial name="_Metadata" model="@Model.Metadata" />
 }

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml.cs
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml.cs
@@ -29,10 +29,25 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             _mediator = mediator;
         }
 
-        public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken, [FromQuery]int page = 1, [FromQuery]string category = null)
+        public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken, [FromQuery] int page = 1, [FromQuery] string category = null, [FromQuery] string q = null)
         {
-            var result = await _mediator.Send(new GetPagedPostListQuery { Page = page, Category = category }, cancellationToken);
+            Result<PostListModel> result;
+            if (!string.IsNullOrWhiteSpace(q))
+                result = await _mediator.Send(new SearchPostsQuery { Page = page, SearchQuery = q }, cancellationToken);
+            else
+                result = await _mediator.Send(new GetPagedPostListQuery { Page = page, Category = category }, cancellationToken);
 
+            return GetPage(result);
+        }
+
+        public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken, [FromForm] string query = null)
+        {
+            var result = await _mediator.Send(new SearchPostsQuery { SearchQuery = query }, cancellationToken);
+            return GetPage(result);
+        }
+
+        private IActionResult GetPage(Result<PostListModel> result)
+        {
             PostList = result.Value;
             Title = result.Value.Blog.Title;
 

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml.cs
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Index.cshtml.cs
@@ -13,6 +13,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
     public class IndexModel : PageModelBase<IndexModel>
     {
         private readonly IMediator _mediator;
+        private readonly IOptionsSnapshot<PineBlogOptions> _options;
 
         public PostListModel PostList { get; set; }
 
@@ -21,12 +22,22 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
         public Models.PageCoverModel PageCover { get; set; }
 
         [ViewData]
+        public bool ShowSearch { get; set; }
+
+        [ViewData]
+        public string SearchQuery { get; set; }
+
+        [ViewData]
         public string Title { get; private set; }
 
-        public IndexModel(IMediator mediator, ILogger<IndexModel> logger)
+        [ViewData]
+        public string BlogTitle { get; private set; }
+
+        public IndexModel(IMediator mediator, IOptionsSnapshot<PineBlogOptions> options, ILogger<IndexModel> logger)
             : base(logger)
         {
             _mediator = mediator;
+            _options = options;
         }
 
         public async Task<IActionResult> OnGetAsync(CancellationToken cancellationToken, [FromQuery] int page = 1, [FromQuery] string category = null, [FromQuery] string q = null)
@@ -40,16 +51,17 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             return GetPage(result);
         }
 
-        public async Task<IActionResult> OnPostAsync(CancellationToken cancellationToken, [FromForm] string query = null)
-        {
-            var result = await _mediator.Send(new SearchPostsQuery { SearchQuery = query }, cancellationToken);
-            return GetPage(result);
-        }
-
         private IActionResult GetPage(Result<PostListModel> result)
         {
             PostList = result.Value;
             Title = result.Value.Blog.Title;
+            ShowSearch = _options.Value.EnableSearch;
+
+            if (PostList.PostListType == PostListType.Search)
+            {
+                BlogTitle = result.Value.Blog.Title;
+                SearchQuery = PostList.SearchQuery;
+            }
 
             Metadata = new Models.MetadataModel
             {

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_BlogLayout.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_BlogLayout.cshtml
@@ -23,5 +23,6 @@
 <div class="pineblog">
     <partial name="_Header" />
     @RenderBody()
+    <partial name="_SearchModal" />
     <partial name="_Footer" />
 </div>

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_Header.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_Header.cshtml
@@ -9,8 +9,8 @@
                 <span class="my-auto">@ViewData["BlogTitle"]</span>
             }
         </a>
-        <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse" id="navbarSupportedContent"></div>
-             @*
+        <div class="navbar-collapse collapse d-inline-flex flex-row-reverse" id="navbarSupportedContent"></div>
+        @*
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
                     aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_Header.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_Header.cshtml
@@ -1,5 +1,5 @@
 @{
-    //var showSearch = ViewData["ShowSearch"] != null && true;
+    var showSearch = ViewData["ShowSearch"] != null && true;
 }
 <header class="blog-header d-flex flex-column">
     <div class="container d-flex">
@@ -9,22 +9,24 @@
                 <span class="my-auto">@ViewData["BlogTitle"]</span>
             }
         </a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
-                aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse" id="navbarSupportedContent">
-            @*<ul class="nav ml-auto my-auto">
-                <li class="nav-item">
-                    <a class="nav-link" asp-area="" asp-page="/Privacy">Privacy</a>
-                </li>
-            </ul>*@
-        </div>
-        @*@if (showSearch)
-            {
-                <button class="blog-search-toggle btn-unstyled" type="button" data-toggle="modal" data-target="#blog-search">
-                    <i class="fa fa-search"></i>
-                </button>
-            }*@
+        <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse" id="navbarSupportedContent"></div>
+             @*
+            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
+                    aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse" id="navbarSupportedContent">
+                <ul class="nav ml-auto my-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" asp-area="" asp-page="/Privacy">Privacy</a>
+                    </li>
+                </ul>
+            </div>
+        *@
+        @if (showSearch) {
+            <button class="blog-search-toggle btn-unstyled" type="button" data-toggle="modal" data-target="#blog-search">
+                <i class="fa fa-search"></i>
+            </button>
+        }
     </div>
 </header>

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_PageCover.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_PageCover.cshtml
@@ -8,6 +8,13 @@
                 @Model.Category
             </a>
         }
+        @*@if (Model.PostListType == Opw.PineBlog.Models.PostListType.Search)
+        {
+            <a href="#">
+                <i class="fa fa-tag" aria-hidden="true"></i>
+                @Model.SearchQuery
+            </a>
+        }*@
         else if (Model.PostListType == Opw.PineBlog.Models.PostListType.Blog)
         {
             <a href="~/">@Model.Title</a>

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_SearchModal.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_SearchModal.cshtml
@@ -1,0 +1,12 @@
+<div class="modal fade blog-search" id="blog-search" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-body p-0">
+                <form role="search" asp-page="Index" asp- method="post">
+                    <input type="search" id="query" name="query" class="form-control form-control-lg" placeholder="Search..." autocomplete="off">
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@*TODO: remove link https://github.com/blogifierdotnet/Blogifier/blob/14c4303a3981bcd0262e0ceaa71df0f31a3bd0e4/src/App/Views/Themes/Standard/_Shared/_Footer.cshtml*@

--- a/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_SearchModal.cshtml
+++ b/src/Opw.PineBlog.RazorPages/Areas/Blog/Pages/Shared/_SearchModal.cshtml
@@ -1,12 +1,17 @@
-<div class="modal fade blog-search" id="blog-search" tabindex="-1" role="dialog" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-body p-0">
-                <form role="search" asp-page="Index" asp- method="post">
-                    <input type="search" id="query" name="query" class="form-control form-control-lg" placeholder="Search..." autocomplete="off">
-                </form>
+@{
+    var showSearch = ViewData["ShowSearch"] != null && true;
+}
+@if (showSearch)
+{
+    <div class="modal fade blog-search" id="blog-search" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-body p-0">
+                    <form role="search" asp-page="Index" asp- method="GET">
+                        <input type="search" id="q" name="q" class="form-control form-control-lg" placeholder="Search .." value="@ViewData["SearchQuery"]" autocomplete="off">
+                    </form>
+                </div>
             </div>
         </div>
     </div>
-</div>
-@*TODO: remove link https://github.com/blogifierdotnet/Blogifier/blob/14c4303a3981bcd0262e0ceaa71df0f31a3bd0e4/src/App/Views/Themes/Standard/_Shared/_Footer.cshtml*@
+}

--- a/src/Opw.PineBlog.RazorPages/Models/PageCoverModel.cs
+++ b/src/Opw.PineBlog.RazorPages/Models/PageCoverModel.cs
@@ -36,5 +36,10 @@ namespace Opw.PineBlog.RazorPages.Models
         /// Category filter.
         /// </summary>
         public string Category { get; set; }
+
+        /// <summary>
+        /// Search query.
+        /// </summary>
+        public string SearchQuery { get; set; }
     }
 }

--- a/src/Opw.PineBlog.RazorPages/MvcBuilderExtensions.cs
+++ b/src/Opw.PineBlog.RazorPages/MvcBuilderExtensions.cs
@@ -60,6 +60,7 @@ namespace Opw.PineBlog.RazorPages
             {
                 options.PagingUrlPartFormat = "page={0}";
                 options.CategoryUrlPartFormat = "category={0}";
+                options.SearchQueryUrlPartFormat = "q={0}";
 
                 var version = typeof(StaticFilePostConfigureOptions).Assembly.GetName().Version;
                 options.Version = version.ToString();

--- a/src/Opw.PineBlog.RazorPages/wwwroot/themes/default/theme.js
+++ b/src/Opw.PineBlog.RazorPages/wwwroot/themes/default/theme.js
@@ -11,33 +11,29 @@ $(function () {
             return $(content).children(".popover-heading").html();
         }
     });
+
+    $('#blog-search').on('show.bs.modal', function () {
+        $(".blog-search-toggle").css({
+            "display": "none"
+        });
+    })
+    $('#blog-search').on('hidden.bs.modal', function () {
+        $(".blog-search-toggle").css({
+            "display": "block"
+        });
+    })
+    $('#blog-search').on('shown.bs.modal', function () {
+        $('#blog-search .form-control').trigger('focus');
+    })
 });
 
-//// logout
-//function profileLogOut() {
-//    $("#frmLogOut").submit();
-//}
-
-//// tooltip
-//$('[data-toggle="tooltip"]').tooltip();
-
-// Create the measurement node for scrollbar
-var scrollDiv = document.createElement("div");
-scrollDiv.className = "scrollbar-measure";
-document.body.appendChild(scrollDiv);
-var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
-document.body.removeChild(scrollDiv);
-
-$('#blog-search').on('show.bs.modal', function () {
-    $(".blog-header").css({
-        "right": scrollbarWidth
-    });
-})
-$('#blog-search').on('hidden.bs.modal', function () {
-    $(".blog-header").css({
-        "right": "0"
-    });
-})
-$('#blog-search').on('shown.bs.modal', function () {
-    $('#blog-search .form-control').trigger('focus');
-})
+function getScrollbarWidth() {
+    // Create the measurement node for scrollbar
+    var scrollDiv = document.createElement("div");
+    scrollDiv.className = "scrollbar-measure";
+    document.body.appendChild(scrollDiv);
+    var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+    document.body.removeChild(scrollDiv);
+    alert(scrollbarWidth);
+    return scrollbarWidth;
+}

--- a/src/Opw.PineBlog.RazorPages/wwwroot/themes/default/theme.js
+++ b/src/Opw.PineBlog.RazorPages/wwwroot/themes/default/theme.js
@@ -21,23 +21,23 @@ $(function () {
 //// tooltip
 //$('[data-toggle="tooltip"]').tooltip();
 
-//// Create the measurement node for scrollbar
-//var scrollDiv = document.createElement("div");
-//scrollDiv.className = "scrollbar-measure";
-//document.body.appendChild(scrollDiv);
-//var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
-//document.body.removeChild(scrollDiv);
+// Create the measurement node for scrollbar
+var scrollDiv = document.createElement("div");
+scrollDiv.className = "scrollbar-measure";
+document.body.appendChild(scrollDiv);
+var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+document.body.removeChild(scrollDiv);
 
-//$('#blog-search').on('show.bs.modal', function () {
-//    $(".blog-header").css({
-//        "right": scrollbarWidth
-//    });
-//})
-//$('#blog-search').on('hidden.bs.modal', function () {
-//    $(".blog-header").css({
-//        "right": "0"
-//    });
-//})
-//$('#blog-search').on('shown.bs.modal', function () {
-//    $('#blog-search .form-control').trigger('focus');
-//})
+$('#blog-search').on('show.bs.modal', function () {
+    $(".blog-header").css({
+        "right": scrollbarWidth
+    });
+})
+$('#blog-search').on('hidden.bs.modal', function () {
+    $(".blog-header").css({
+        "right": "0"
+    });
+})
+$('#blog-search').on('shown.bs.modal', function () {
+    $('#blog-search .form-control').trigger('focus');
+})

--- a/tests/Opw.PineBlog.Core.Tests/Posts/SearchPostsQueryTests.cs
+++ b/tests/Opw.PineBlog.Core.Tests/Posts/SearchPostsQueryTests.cs
@@ -12,20 +12,20 @@ using Xunit;
 
 namespace Opw.PineBlog.Posts
 {
-    public class GetPagedPostListQueryTests : MediatRTestsBase
+    public class SearchPostsQueryTests : MediatRTestsBase
     {
         private Guid _authorId = Guid.NewGuid();
 
-        public GetPagedPostListQueryTests() : base()
+        public SearchPostsQueryTests()
         {
             var author = new Author { Id = _authorId, UserName = "user@example.com", DisplayName = "Author 1" };
 
             var posts = new List<Post>();
-            posts.Add(CreatePost(0, author, false, "cat1"));
-            posts.Add(CreatePost(1, author, true, "cat1"));
-            posts.Add(CreatePost(2, author, true, "cat1"));
-            posts.Add(CreatePost(3, author, true, "cat1"));
-            posts.Add(CreatePost(4, author, true, "cat1"));
+            posts.Add(CreatePost(0, author, false));
+            posts.Add(CreatePost(1, author, true));
+            posts.Add(CreatePost(2, author, true));
+            posts.Add(CreatePost(3, author, true));
+            posts.Add(CreatePost(4, author, true));
 
             PostRepositoryMock.Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(posts);
             PostRepositoryMock.Setup(m => m.CountAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<CancellationToken>())).ReturnsAsync(posts.Count);
@@ -34,7 +34,7 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_GetPosts_ForPage1()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 1 });
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1 });
 
             result.IsSuccess.Should().BeTrue();
 
@@ -44,7 +44,7 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_GetPosts_ForPage1_WithItemsPerPage2()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 1, ItemsPerPage = 2 });
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, ItemsPerPage = 2 });
 
             result.IsSuccess.Should().BeTrue();
 
@@ -54,7 +54,7 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_GetPosts_ForPage2()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 2 });
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 2 });
 
             result.IsSuccess.Should().BeTrue();
 
@@ -62,43 +62,9 @@ namespace Opw.PineBlog.Posts
         }
 
         [Fact]
-        public async Task Handler_Should_Predicates_PublishedExpression_WhenNotIncludingUnpublishedPosts()
-        {
-            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
-
-            PostRepositoryMock
-                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
-
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 1, IncludeUnpublished = false, ItemsPerPage = 100 });
-
-            result.IsSuccess.Should().BeTrue();
-
-            Expression<Func<Post, bool>> publishedExpression = p => p.Published != null;
-            createdPredicates.Should().ContainEquivalentOf(publishedExpression);
-        }
-
-        [Fact]
-        public async Task Handler_Should_Predicates_Empty_WhenIncludingUnpublishedPosts()
-        {
-            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
-
-            PostRepositoryMock
-                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
-
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 1, IncludeUnpublished = true, ItemsPerPage = 100 });
-
-            result.IsSuccess.Should().BeTrue();
-
-            Expression<Func<Post, bool>> publishedExpression = p => p.Published != null;
-            createdPredicates.Should().BeEmpty();
-        }
-
-        [Fact]
         public async Task Handler_Should_ReturnPostListModel_WithBlogCoverUrlFormatReplaced()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Blog.CoverUrl.Should().Be("http://127.0.0.1:10000/devstoreaccount1/pineblog-tests/blog/cover-image.png");
@@ -107,34 +73,34 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_ReturnPostListModel_WithPostListTypeBlog()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.PostListType.Should().Be(PostListType.Blog);
         }
 
         [Fact]
-        public async Task Handler_Should_ReturnPostListModel_WithPostListCategory()
+        public async Task Handler_Should_ReturnPostListModel_WithPostListTypeSearch()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery { Category = "text" });
+            var result = await Mediator.Send(new SearchPostsQuery { SearchQuery = "text" });
 
             result.IsSuccess.Should().BeTrue();
-            result.Value.Category.Should().Be("text");
+            result.Value.PostListType.Should().Be(PostListType.Search);
         }
 
         [Fact]
-        public async Task Handler_Should_ReturnPostListModel_WhenFilterOnCategory_WithPostListTypeCategory()
+        public async Task Handler_Should_ReturnPostListModel_WithPostListSearchQuery()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery { Category = "category" });
+            var result = await Mediator.Send(new SearchPostsQuery { SearchQuery = "text" });
 
             result.IsSuccess.Should().BeTrue();
-            result.Value.PostListType.Should().Be(PostListType.Category);
+            result.Value.SearchQuery.Should().Be("text");
         }
 
         [Fact]
         public async Task Handler_Should_ReturnPostListModel_WithBlogInfo()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Blog.Title.Should().Be("Title from configuration");
@@ -143,7 +109,7 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_ReturnPostListModel_WithPostCovers()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Posts.First().CoverUrl.Should().BeNull();
@@ -153,7 +119,7 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_CoverUrl_ReplaceBaseUrlWithUrlFormat()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
 
@@ -164,18 +130,18 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_UrlsInContent_ReplaceBaseUrlWithUrlFormat()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
 
             result.Value.Should().NotBeNull();
-            result.Value.Posts.Last().Content.Should().Be("Content with a url: http://127.0.0.1:10000/devstoreaccount1/pineblog-tests/content-url");
+            result.Value.Posts.Last().Content.Should().Be("content with a url: http://127.0.0.1:10000/devstoreaccount1/pineblog-tests/content-url");
         }
 
         [Fact]
         public async Task Handler_Should_ReturnPostListModel_WithPostAuthors()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Posts.First().Author.DisplayName.Should().Be("Author 1");
@@ -184,7 +150,7 @@ namespace Opw.PineBlog.Posts
         [Fact]
         public async Task Handler_Should_ReturnPostListModel_WithPager()
         {
-            var result = await Mediator.Send(new GetPagedPostListQuery());
+            var result = await Mediator.Send(new SearchPostsQuery());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Pager.CurrentPage.Should().Be(1);
@@ -192,7 +158,7 @@ namespace Opw.PineBlog.Posts
         }
 
         [Fact]
-        public async Task Handler_Should_Predicates_CategoryExpression_ForCategoryCat2()
+        public async Task Handler_Should_Predicates_CategoriesExpression_ForSearchQuery()
         {
             IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
 
@@ -200,16 +166,16 @@ namespace Opw.PineBlog.Posts
                 .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
 
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 1, Category = "cat2", ItemsPerPage = 100 });
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
 
             result.IsSuccess.Should().BeTrue();
 
-            Expression<Func<Post, bool>> categoryExpression = p => p.Categories.Contains("cat2");
-            createdPredicates.Should().ContainEquivalentOf(categoryExpression);
+            Expression<Func<Post, bool>> categoriesExpression = p => p.Categories.Contains("text");
+            createdPredicates.Should().ContainEquivalentOf(categoriesExpression);
         }
 
         [Fact]
-        public async Task Handler_Should_Predicates_CategoryExpressionAndPublishedExpression_ForCategoryCat2AndIncludeUnpublishedFalse()
+        public async Task Handler_Should_Predicates_DescriptionExpression_ForSearchQuery()
         {
             IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
 
@@ -217,26 +183,58 @@ namespace Opw.PineBlog.Posts
                 .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
 
-            var result = await Mediator.Send(new GetPagedPostListQuery { Page = 1, IncludeUnpublished = false, Category = "cat3", ItemsPerPage = 100 });
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
 
             result.IsSuccess.Should().BeTrue();
 
-            Expression<Func<Post, bool>> categoryExpression = p => p.Categories.Contains("cat2");
-            createdPredicates.Should().ContainEquivalentOf(categoryExpression);
-            Expression<Func<Post, bool>> publishedExpression = p => p.Published != null;
-            createdPredicates.Should().ContainEquivalentOf(publishedExpression);
+            Expression<Func<Post, bool>> descriptionExpression = p => p.Description.Contains("text");
+            createdPredicates.Should().ContainEquivalentOf(descriptionExpression);
         }
 
-        private Post CreatePost(int i, Author author, bool cover, string categories)
+        [Fact]
+        public async Task Handler_Should_Predicates_ContentExpression_ForSearchQuery()
+        {
+            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
+
+            PostRepositoryMock
+                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
+
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
+
+            result.IsSuccess.Should().BeTrue();
+
+            Expression<Func<Post, bool>> contentExpression = p => p.Content.Contains("text");
+            createdPredicates.Should().ContainEquivalentOf(contentExpression);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Predicates_TitleExpression_ForSearchQuery()
+        {
+            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
+
+            PostRepositoryMock
+                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
+
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
+
+            result.IsSuccess.Should().BeTrue();
+
+            Expression<Func<Post, bool>> titleExpression = p => p.Title.Contains("text");
+            createdPredicates.Should().ContainEquivalentOf(titleExpression);
+        }
+
+        private Post CreatePost(int i, Author author, bool cover)
         {
             var post = new Post
             {
                 Author = author,
-                Title = "Post title " + i,
-                Slug = "post-title-" + i,
-                Categories = categories,
-                Description = "Description",
-                Content = "Content with a url: %URL%/content-url",
+                Title = "title" + i,
+                Slug = "slug" + i,
+                Categories = "categories",
+                Description = "description",
+                Content = "content with a url: %URL%/content-url",
                 Created = DateTime.UtcNow,
                 Modified = DateTime.UtcNow,
                 Published = DateTime.UtcNow

--- a/tests/Opw.PineBlog.Core.Tests/Posts/SearchPostsQueryTests.cs
+++ b/tests/Opw.PineBlog.Core.Tests/Posts/SearchPostsQueryTests.cs
@@ -158,7 +158,7 @@ namespace Opw.PineBlog.Posts
         }
 
         [Fact]
-        public async Task Handler_Should_Predicates_CategoriesExpression_ForSearchQuery()
+        public async Task Handler_Should_Predicates_SearchExpression()
         {
             IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
 
@@ -166,63 +166,21 @@ namespace Opw.PineBlog.Posts
                 .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
                 .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
 
-            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
+            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text text2", ItemsPerPage = 100 });
 
             result.IsSuccess.Should().BeTrue();
 
-            Expression<Func<Post, bool>> categoriesExpression = p => p.Categories.Contains("text");
-            createdPredicates.Should().ContainEquivalentOf(categoriesExpression);
-        }
+            var predicate = createdPredicates.Where(p =>
+                p.Body.ToString().Contains("p.Title.Contains(\"text\")")
+                && p.Body.ToString().Contains("p.Title.Contains(\"text2\")")
+                && p.Body.ToString().Contains("OrElse p.Description.Contains(\"text\")")
+                && p.Body.ToString().Contains("OrElse p.Description.Contains(\"text2\")")
+                && p.Body.ToString().Contains("OrElse p.Categories.Contains(\"text\")")
+                && p.Body.ToString().Contains("OrElse p.Categories.Contains(\"text2\")")
+                && p.Body.ToString().Contains("OrElse p.Content.Contains(\"text\")")
+                && p.Body.ToString().Contains("OrElse p.Content.Contains(\"text2\")"));
 
-        [Fact]
-        public async Task Handler_Should_Predicates_DescriptionExpression_ForSearchQuery()
-        {
-            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
-
-            PostRepositoryMock
-                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
-
-            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
-
-            result.IsSuccess.Should().BeTrue();
-
-            Expression<Func<Post, bool>> descriptionExpression = p => p.Description.Contains("text");
-            createdPredicates.Should().ContainEquivalentOf(descriptionExpression);
-        }
-
-        [Fact]
-        public async Task Handler_Should_Predicates_ContentExpression_ForSearchQuery()
-        {
-            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
-
-            PostRepositoryMock
-                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
-
-            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
-
-            result.IsSuccess.Should().BeTrue();
-
-            Expression<Func<Post, bool>> contentExpression = p => p.Content.Contains("text");
-            createdPredicates.Should().ContainEquivalentOf(contentExpression);
-        }
-
-        [Fact]
-        public async Task Handler_Should_Predicates_TitleExpression_ForSearchQuery()
-        {
-            IEnumerable<Expression<Func<Post, bool>>> createdPredicates = new List<Expression<Func<Post, bool>>>();
-
-            PostRepositoryMock
-                .Setup(m => m.GetAsync(It.IsAny<IEnumerable<Expression<Func<Post, bool>>>>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-                .Callback((IEnumerable<Expression<Func<Post, bool>>> predicates, int _, int __, CancellationToken ___) => createdPredicates = predicates);
-
-            var result = await Mediator.Send(new SearchPostsQuery { Page = 1, SearchQuery = "text", ItemsPerPage = 100 });
-
-            result.IsSuccess.Should().BeTrue();
-
-            Expression<Func<Post, bool>> titleExpression = p => p.Title.Contains("text");
-            createdPredicates.Should().ContainEquivalentOf(titleExpression);
+            predicate.Should().NotBeNull();
         }
 
         private Post CreatePost(int i, Author author, bool cover)

--- a/tests/Opw.PineBlog.Core.Tests/appsettings.json
+++ b/tests/Opw.PineBlog.Core.Tests/appsettings.json
@@ -6,6 +6,7 @@
     "Title": "Title from configuration",
     "PagingUrlPartFormat": "page={0}",
     "CategoryUrlPartFormat": "category={0}",
+    "SearchQueryUrlPartFormat": "q={0}",
     "CoverUrl": "%URL%/blog/cover-image.png",
     "ItemsPerPage": 3,
     "ConnectionStringName": "DefaultConnection",

--- a/tests/Opw.PineBlog.EntityFrameworkCore.Tests/Posts/SearchPostsQueryTests.cs
+++ b/tests/Opw.PineBlog.EntityFrameworkCore.Tests/Posts/SearchPostsQueryTests.cs
@@ -1,0 +1,171 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Opw.PineBlog.Entities;
+using Opw.PineBlog.EntityFrameworkCore;
+using Opw.PineBlog.Files;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opw.PineBlog.Posts
+{
+    public class SearchPostsQueryTests : EntityFrameworkCoreTestsBase
+    {
+        private readonly SearchPostsQuery.Handler searchPostsQueryHandler;
+
+        public SearchPostsQueryTests()
+        {
+            SeedDatabase();
+
+            var uow = ServiceProvider.GetRequiredService<IBlogUnitOfWork>();
+            var options = ServiceProvider.GetRequiredService<IOptionsSnapshot<PineBlogOptions>>();
+            var postUrlHelper = ServiceProvider.GetRequiredService<PostUrlHelper>();
+            var fileUrlHelper = ServiceProvider.GetRequiredService<FileUrlHelper>();
+
+            searchPostsQueryHandler = new SearchPostsQuery.Handler(uow, options, postUrlHelper, fileUrlHelper);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return6Posts_MatchOnTitle()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return1Post_MatchOnTitle()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return6Post_MatchOnCategories()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "categories", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return2Post_MatchOnCategories()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "catc", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return6Post_MatchOnDescription()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "description", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return1Post_MatchOnDescription()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "description1", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return6Post_MatchOnContent()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "content", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return1Post_MatchOnContent()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "content1", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return2Post_MultipleTerms_MatchOnTitle()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1 title2", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return2Post_MultipleTerms_MatchOnTitleAndDescription()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1 description2", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public async Task Handler_Should_Return3Post_MultipleTerms_MatchOnTitleAndCategories()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1 catc", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(3);
+        }
+
+        private void SeedDatabase()
+        {
+            var context = ServiceProvider.GetRequiredService<BlogEntityDbContext>();
+
+            var author = new Author { UserName = "user@example.com", DisplayName = "Author 1" };
+            context.Authors.Add(author);
+            context.SaveChanges();
+
+            context.Posts.Add(CreatePost(0, author.Id, "cata"));
+            context.Posts.Add(CreatePost(1, author.Id, "cata"));
+            context.Posts.Add(CreatePost(2, author.Id, "cata,catb"));
+            context.Posts.Add(CreatePost(3, author.Id, "catb"));
+            context.Posts.Add(CreatePost(4, author.Id, "cata,catb,catc"));
+            context.Posts.Add(CreatePost(5, author.Id, "catc"));
+            context.SaveChanges();
+        }
+
+        private Post CreatePost(int i, Guid authorId, string categories)
+        {
+            return new Post
+            {
+                AuthorId = authorId,
+                Title = "title aaa title" + i,
+                Slug = "title-aaa-" + i,
+                Categories = $"categories,{categories}",
+                Description = "description aaa description" + i,
+                Content = "content ccc content" + i,
+                Published = DateTime.UtcNow.AddDays(-i)
+            };
+        }
+    }
+}

--- a/tests/Opw.PineBlog.EntityFrameworkCore.Tests/appsettings.json
+++ b/tests/Opw.PineBlog.EntityFrameworkCore.Tests/appsettings.json
@@ -4,6 +4,7 @@
   },
   "PineBlogOptions": {
     "ConnectionStringName": "DefaultConnection",
-    "Title": "Test Blog"
+    "Title": "Test Blog",
+    "SearchQueryUrlPartFormat": "q={0}"
   }
 }

--- a/tests/Opw.PineBlog.MongoDb.Tests/BlogSettingsConfigurationProviderTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/BlogSettingsConfigurationProviderTests.cs
@@ -10,7 +10,7 @@ namespace Opw.PineBlog.MongoDb
     {
         private readonly BlogSettingsConfigurationProvider _provider;
 
-        public BlogSettingsConfigurationProviderTests()
+        public BlogSettingsConfigurationProviderTests(MongoDbDatabaseFixture fixture) : base(fixture)
         {
             var connectionStringName = Configuration.GetSection(nameof(PineBlogOptions)).GetValue<string>(nameof(PineBlogOptions.ConnectionStringName));
             var databaseName = Configuration.GetSection(nameof(PineBlogOptions)).GetValue<string>(nameof(PineBlogOptions.MongoDbDatabaseName));

--- a/tests/Opw.PineBlog.MongoDb.Tests/Constants.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Constants.cs
@@ -5,7 +5,7 @@ namespace Opw.PineBlog.MongoDb
     {
         // tests are not skipped since they are now working on the build agent as well
         // TODO: re-enable MongoDb tests
-        public const string SkipMongoDbTests = "Requires MongoDb in memory database (that does not work on the build server).";
+        public const string SkipMongoDbTests = null; // "Requires MongoDb in memory database (that does not work on the build server).";
         public const string SkipMongoDbBlogSettingsConfigurationProviderTests = "These tests do not work on the build server.";
     }
 }

--- a/tests/Opw.PineBlog.MongoDb.Tests/Constants.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Constants.cs
@@ -4,7 +4,8 @@ namespace Opw.PineBlog.MongoDb
     public static class Constants
     {
         // tests are not skipped since they are now working on the build agent as well
-        public const string SkipMongoDbTests = null; // "Requires MongoDb in memory database (that does not work on the build server).";
+        // TODO: re-enable MongoDb tests
+        public const string SkipMongoDbTests = "Requires MongoDb in memory database (that does not work on the build server).";
         public const string SkipMongoDbBlogSettingsConfigurationProviderTests = "These tests do not work on the build server.";
     }
 }

--- a/tests/Opw.PineBlog.MongoDb.Tests/Constants.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Constants.cs
@@ -4,8 +4,7 @@ namespace Opw.PineBlog.MongoDb
     public static class Constants
     {
         // tests are not skipped since they are now working on the build agent as well
-        // TODO: re-enable MongoDb tests
-        public const string SkipMongoDbTests = null; // "Requires MongoDb in memory database (that does not work on the build server).";
+        public const string SkipMongoDbTests = null; //"Requires MongoDb in memory database (that does not work on the build server).";
         public const string SkipMongoDbBlogSettingsConfigurationProviderTests = "These tests do not work on the build server.";
     }
 }

--- a/tests/Opw.PineBlog.MongoDb.Tests/MongoDbDatabaseCollection.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/MongoDbDatabaseCollection.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace Opw.PineBlog.MongoDb
+{
+    [CollectionDefinition(nameof(MongoDbDatabaseCollection))]
+    public class MongoDbDatabaseCollection : ICollectionFixture<MongoDbDatabaseFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/tests/Opw.PineBlog.MongoDb.Tests/MongoDbDatabaseFixture.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/MongoDbDatabaseFixture.cs
@@ -1,0 +1,38 @@
+using Mongo2Go;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace Opw.PineBlog.MongoDb
+{
+    public sealed class MongoDbDatabaseFixture : IDisposable
+    {
+        public MongoDbRunner Runner { get; private set; }
+
+        public MongoDbDatabaseFixture()
+        {
+            Runner = MongoDbRunner.Start(singleNodeReplSet: true);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing) { }
+
+            // always try to dispose, even if disposing=false
+            if (Runner != null)
+            {
+                // wait a little to prevent timeouts
+                Thread.Sleep(500);
+                try { Runner?.Dispose(); } catch { }
+                Runner = null;
+                GC.Collect();
+            }
+        }
+    }
+}

--- a/tests/Opw.PineBlog.MongoDb.Tests/MongoDbTestsBase.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/MongoDbTestsBase.cs
@@ -1,18 +1,16 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Mongo2Go;
 using MongoDB.Driver;
 using Opw.PineBlog.Entities;
 using System;
 using System.Collections.Generic;
-using System.Threading;
+using Xunit;
 
 namespace Opw.PineBlog.MongoDb
 {
-    public abstract class MongoDbTestsBase : IDisposable
+    [Collection(nameof(MongoDbDatabaseCollection))]
+    public abstract class MongoDbTestsBase
     {
-        private static MongoDbRunner _runner;
-
         protected readonly IServiceCollection Services;
         protected readonly IConfiguration Configuration;
         protected readonly IMongoCollection<BlogSettings> BlogSettingsCollection;
@@ -21,10 +19,9 @@ namespace Opw.PineBlog.MongoDb
 
         protected IServiceProvider ServiceProvider => Services.BuildServiceProvider();
 
-        public MongoDbTestsBase()
+        public MongoDbTestsBase(MongoDbDatabaseFixture fixture)
         {
-            _runner = MongoDbRunner.Start(singleNodeReplSet: true);
-            Configuration = BuildConfiguration(_runner.ConnectionString);
+            Configuration = BuildConfiguration(fixture.Runner.ConnectionString);
 
             Services = new ServiceCollection();
             Services.AddPineBlogCore(Configuration);
@@ -48,29 +45,6 @@ namespace Opw.PineBlog.MongoDb
                .AddJsonFile("appsettings.json")
                .AddInMemoryCollection(settings)
                .Build();
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-            }
-
-            // always try to dispose, even if disposing=false
-            if (_runner != null)
-            {
-                // wait a little to prevent timeouts
-                Thread.Sleep(500);
-                try { _runner?.Dispose(); } catch { }
-                _runner = null;
-                GC.Collect();
-            }
         }
     }
 }

--- a/tests/Opw.PineBlog.MongoDb.Tests/Posts/SearchPostsQueryTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Posts/SearchPostsQueryTests.cs
@@ -1,0 +1,172 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Opw.PineBlog.Entities;
+using Opw.PineBlog.Files;
+using Opw.PineBlog.MongoDb;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Opw.PineBlog.Posts
+{
+    public class SearchPostsQueryTests : MongoDbTestsBase
+    {
+        private readonly SearchPostsQuery.Handler searchPostsQueryHandler;
+
+        public SearchPostsQueryTests()
+        {
+            SeedDatabase();
+
+            var uow = ServiceProvider.GetRequiredService<IBlogUnitOfWork>();
+            var options = ServiceProvider.GetRequiredService<IOptionsSnapshot<PineBlogOptions>>();
+            var postUrlHelper = ServiceProvider.GetRequiredService<PostUrlHelper>();
+            var fileUrlHelper = ServiceProvider.GetRequiredService<FileUrlHelper>();
+
+            searchPostsQueryHandler = new SearchPostsQuery.Handler(uow, options, postUrlHelper, fileUrlHelper);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return6Posts_MatchOnTitle()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return1Post_MatchOnTitle()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(1);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return6Post_MatchOnCategories()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "categories", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return2Post_MatchOnCategories()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "catc", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(2);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return6Post_MatchOnDescription()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "description", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return1Post_MatchOnDescription()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "description1", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(1);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return6Post_MatchOnContent()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "content", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(6);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return1Post_MatchOnContent()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "content1", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(1);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return2Post_MultipleTerms_MatchOnTitle()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1 title2", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(2);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return2Post_MultipleTerms_MatchOnTitleAndDescription()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1 description2", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(2);
+        }
+
+        [Fact(Skip = Constants.SkipMongoDbTests)]
+        public async Task Handler_Should_Return3Post_MultipleTerms_MatchOnTitleAndCategories()
+        {
+            var result = await searchPostsQueryHandler.Handle(new SearchPostsQuery { Page = 1, SearchQuery = "title1 catc", ItemsPerPage = 100 }, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+
+            result.Value.Posts.Should().HaveCount(3);
+        }
+
+        private void SeedDatabase()
+        {
+            var authorId = Guid.NewGuid();
+            AuthorCollection.InsertOne(new Author
+            {
+                Id = authorId,
+                DisplayName = "Author 1",
+                UserName = "user@example.com"
+            });
+
+            PostCollection.InsertOne(CreatePost(0, authorId, "cata"));
+            PostCollection.InsertOne(CreatePost(1, authorId, "cata"));
+            PostCollection.InsertOne(CreatePost(2, authorId, "cata,catb"));
+            PostCollection.InsertOne(CreatePost(3, authorId, "catb"));
+            PostCollection.InsertOne(CreatePost(4, authorId, "cata,catb,catc"));
+            PostCollection.InsertOne(CreatePost(5, authorId, "catc"));
+        }
+
+        private Post CreatePost(int i, Guid authorId, string categories)
+        {
+            return new Post
+            {
+                AuthorId = authorId,
+                Title = "title aaa title" + i,
+                Slug = "title-aaa-" + i,
+                Categories = $"categories,{categories}",
+                Description = "description aaa description" + i,
+                Content = "content ccc content" + i,
+                Published = DateTime.UtcNow.AddDays(-i)
+            };
+        }
+    }
+}

--- a/tests/Opw.PineBlog.MongoDb.Tests/Posts/SearchPostsQueryTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Posts/SearchPostsQueryTests.cs
@@ -15,7 +15,7 @@ namespace Opw.PineBlog.Posts
     {
         private readonly SearchPostsQuery.Handler searchPostsQueryHandler;
 
-        public SearchPostsQueryTests()
+        public SearchPostsQueryTests(MongoDbDatabaseFixture fixture) : base(fixture)
         {
             SeedDatabase();
 

--- a/tests/Opw.PineBlog.MongoDb.Tests/Repositories/AuthorRepositoryTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Repositories/AuthorRepositoryTests.cs
@@ -12,7 +12,7 @@ namespace Opw.PineBlog.MongoDb.Repositories
     {
         private readonly AuthorRepository _repository;
 
-        public AuthorRepositoryTests()
+        public AuthorRepositoryTests(MongoDbDatabaseFixture fixture) : base(fixture)
         {
             SeedDatabase();
 

--- a/tests/Opw.PineBlog.MongoDb.Tests/Repositories/BlogSettingsRepositoryTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Repositories/BlogSettingsRepositoryTests.cs
@@ -15,7 +15,7 @@ namespace Opw.PineBlog.MongoDb.Repositories
         private readonly BlogSettingsRepository _blogSettingsRepository;
         private readonly IBlogUnitOfWork _uow;
 
-        public BlogSettingsRepositoryTests()
+        public BlogSettingsRepositoryTests(MongoDbDatabaseFixture fixture) : base(fixture)
         {
             _uow = ServiceProvider.GetRequiredService<IBlogUnitOfWork>();
             _blogSettingsRepository = (BlogSettingsRepository)_uow.BlogSettings;

--- a/tests/Opw.PineBlog.MongoDb.Tests/Repositories/PostRepositoryTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/Repositories/PostRepositoryTests.cs
@@ -18,7 +18,7 @@ namespace Opw.PineBlog.MongoDb.Repositories
         private readonly PostRepository _postRepository;
         private readonly IBlogUnitOfWork _uow;
 
-        public PostRepositoryTests()
+        public PostRepositoryTests(MongoDbDatabaseFixture fixture) : base(fixture)
         {
             SeedDatabase();
 

--- a/tests/Opw.PineBlog.MongoDb.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Opw.PineBlog.MongoDb.Tests/ServiceCollectionExtensionsTests.cs
@@ -6,6 +6,8 @@ namespace Opw.PineBlog.MongoDb
 {
     public class ServiceCollectionExtensionsTests : MongoDbTestsBase
     {
+        public ServiceCollectionExtensionsTests(MongoDbDatabaseFixture fixture) : base(fixture) { }
+
         [Fact(Skip = Constants.SkipMongoDbTests)]
         public void AddPineBlogMongoDb_Should_RegisterBlogUnitOfWork()
         {

--- a/tests/Opw.PineBlog.MongoDb.Tests/appsettings.json
+++ b/tests/Opw.PineBlog.MongoDb.Tests/appsettings.json
@@ -4,6 +4,7 @@
   },
   "PineBlogOptions": {
     "ConnectionStringName": "MongoDbConnection",
-    "MongoDbDatabaseName": "pineblog-db"
+    "MongoDbDatabaseName": "pineblog-db",
+    "SearchQueryUrlPartFormat": "q={0}"
   }
 }

--- a/tests/Opw.PineBlog.RazorPages.Tests/Areas/Blog/Pages/IndexModelTests.cs
+++ b/tests/Opw.PineBlog.RazorPages.Tests/Areas/Blog/Pages/IndexModelTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Opw.PineBlog.Entities;
 using Opw.PineBlog.Models;
@@ -14,12 +15,23 @@ using Xunit;
 
 namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
 {
+    // TODO: improve test coverage (for search)
     public class IndexModelTests : RazorPagesTestsBase
     {
+        private readonly Mock<ILogger<IndexModel>> _loggerMock;
+        private readonly Mock<IOptionsSnapshot<PineBlogOptions>> _optionsMock;
+
+        public IndexModelTests()
+        {
+            _loggerMock = new Mock<ILogger<IndexModel>>();
+
+            _optionsMock = new Mock<IOptionsSnapshot<PineBlogOptions>>();
+            _optionsMock.SetupGet(m => m.Value).Returns(new PineBlogOptions());
+        }
+
         [Fact]
         public async Task OnGetAsync_Should_SetPostListModel()
         {
-            var loggerMock = new Mock<ILogger<IndexModel>>();
             var mediaterMock = new Mock<IMediator>();
             mediaterMock.Setup(m => m.Send(It.IsAny<IRequest<Result<PostListModel>>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<PostListModel>.Success(GetPostListModel()));
@@ -27,7 +39,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             var httpContext = new DefaultHttpContext();
             var pageContext = GetPageContext(httpContext);
 
-            var pageModel = new IndexModel(mediaterMock.Object, loggerMock.Object)
+            var pageModel = new IndexModel(mediaterMock.Object, _optionsMock.Object, _loggerMock.Object)
             {
                 PageContext = pageContext.Item1,
                 TempData = GetTempDataDictionary(httpContext),
@@ -49,7 +61,6 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
         [Fact]
         public async Task OnGetAsync_Should_SetMetadataModel()
         {
-            var loggerMock = new Mock<ILogger<IndexModel>>();
             var mediaterMock = new Mock<IMediator>();
             mediaterMock.Setup(m => m.Send(It.IsAny<IRequest<Result<PostListModel>>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<PostListModel>.Success(GetPostListModel()));
@@ -57,7 +68,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             var httpContext = new DefaultHttpContext();
             var pageContext = GetPageContext(httpContext);
 
-            var pageModel = new IndexModel(mediaterMock.Object, loggerMock.Object)
+            var pageModel = new IndexModel(mediaterMock.Object, _optionsMock.Object, _loggerMock.Object)
             {
                 PageContext = pageContext.Item1,
                 TempData = GetTempDataDictionary(httpContext),
@@ -74,7 +85,6 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
         [Fact]
         public async Task OnGetAsync_Should_SetPageCoverModel_WhenNoFilters()
         {
-            var loggerMock = new Mock<ILogger<IndexModel>>();
             var mediaterMock = new Mock<IMediator>();
             mediaterMock.Setup(m => m.Send(It.IsAny<IRequest<Result<PostListModel>>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<PostListModel>.Success(GetPostListModel()));
@@ -82,7 +92,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             var httpContext = new DefaultHttpContext();
             var pageContext = GetPageContext(httpContext);
 
-            var pageModel = new IndexModel(mediaterMock.Object, loggerMock.Object)
+            var pageModel = new IndexModel(mediaterMock.Object, _optionsMock.Object, _loggerMock.Object)
             {
                 PageContext = pageContext.Item1,
                 TempData = GetTempDataDictionary(httpContext),
@@ -99,7 +109,6 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
         [Fact]
         public async Task OnGetAsync_Should_SetPageCoverModel_WhenFilterOnCategory()
         {
-            var loggerMock = new Mock<ILogger<IndexModel>>();
             var postListModel = GetPostListModel();
             postListModel.PostListType = PostListType.Category;
             postListModel.Category = "category";
@@ -111,7 +120,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             var httpContext = new DefaultHttpContext();
             var pageContext = GetPageContext(httpContext);
 
-            var pageModel = new IndexModel(mediaterMock.Object, loggerMock.Object)
+            var pageModel = new IndexModel(mediaterMock.Object, _optionsMock.Object, _loggerMock.Object)
             {
                 PageContext = pageContext.Item1,
                 TempData = GetTempDataDictionary(httpContext),
@@ -128,8 +137,6 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
         [Fact]
         public async Task OnGetAsync_Should_SetAbsoluteCoverUrl()
         {
-            var loggerMock = new Mock<ILogger<IndexModel>>();
-
             var postListModel = GetPostListModel();
             postListModel.Blog.CoverUrl = "http://www.example.com/images.jpg";
 
@@ -140,7 +147,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             var httpContext = new DefaultHttpContext();
             var pageContext = GetPageContext(httpContext);
 
-            var pageModel = new IndexModel(mediaterMock.Object, loggerMock.Object)
+            var pageModel = new IndexModel(mediaterMock.Object, _optionsMock.Object, _loggerMock.Object)
             {
                 PageContext = pageContext.Item1,
                 TempData = GetTempDataDictionary(httpContext),
@@ -158,8 +165,6 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
         [Fact]
         public async Task OnGetAsync_Should_SetRelativeCoverUrl()
         {
-            var loggerMock = new Mock<ILogger<IndexModel>>();
-
             var postListModel = GetPostListModel();
             postListModel.Blog.CoverUrl = "/images.jpg";
 
@@ -172,7 +177,7 @@ namespace Opw.PineBlog.RazorPages.Areas.Blog.Pages
             httpContext.Request.Host = new HostString("localhost:5001");
             var pageContext = GetPageContext(httpContext);
 
-            var pageModel = new IndexModel(mediaterMock.Object, loggerMock.Object)
+            var pageModel = new IndexModel(mediaterMock.Object, _optionsMock.Object, _loggerMock.Object)
             {
                 PageContext = pageContext.Item1,
                 TempData = GetTempDataDictionary(httpContext),


### PR DESCRIPTION
Enable the search functionality in the `_Header.cshtml`.

Search in the following fields:
- `Post.Title`
- `Post.Description`
- `Post.Content`
- `Post.Categories`

Search method `freetext`, with more weight on the `Post.Categories` and `Post.Title`.

issue: #108 